### PR TITLE
change to pg_postmaster_start_time_seconds

### DIFF
--- a/dashboards/postgresql-database.json
+++ b/dashboards/postgresql-database.json
@@ -215,7 +215,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "process_start_time_seconds{release=\"$release\", instance=\"$instance\"} * 1000",
+          "expr": "pg_postmaster_start_time_seconds{release=\"$release\", instance=\"$instance\"} * 1000",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "",


### PR DESCRIPTION
process_start_time_seconds show uptime process postgres_exporter!
process_start_time_seconds not show uptime process postgres/postmaster!

Needd change to pg_postmaster_start_time_seconds{release="$release", instance="$instance"} * 1000
https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml#L9