### PR TITLE
Change query to show only relevant instances in the dropdown menu

### DIFF
--- a/dashboards/postgresql-database.json
+++ b/dashboards/postgresql-database.json
@@ -3064,7 +3064,7 @@
         "multi": false,
         "name": "instance",
         "options": [],
-        "query": "query_result(up{release=\"$release\"})",
+        "query": "query_result(pg_up{release=\"$release\"})",
         "refresh": 1,
         "regex": "/.*instance=\"([^\"]+).*/",
         "skipUrlSync": false,


### PR DESCRIPTION
Change query to only include instances with "pg_up" metric.
Fixes: https://github.com/lstn/misc-grafana-dashboards/issues/5