### PR TITLE
Fix issue with dashboard provisioning

### DIFF
--- a/dashboards/postgresql-database.json
+++ b/dashboards/postgresql-database.json
@@ -2952,6 +2952,16 @@
   "templating": {
     "list": [
       {
+        "hide": 0,
+        "label": "datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
         "auto": true,
         "auto_count": 200,
         "auto_min": "1s",


### PR DESCRIPTION
This fixes the error "Datasource named ${DS_PROMETHEUS} was not found" and makes it possible to provision the dashboard via grafana dashboards sidecar.

Taken from here: https://github.com/grafana/grafana/issues/10786#issuecomment-734447429